### PR TITLE
feat: handle all playwright status for QA touch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -20,17 +20,30 @@ class QATouchReporter {
     }
 
     onTestEnd(test, result) {
-        if (result.status === 'passed') {
-            const status_id = this.qaTouch.statusConfig('Passed');
-            const caseIds = this.qaTouch.TitleToCaseIds(test.title);
+        const caseIds = this.qaTouch.TitleToCaseIds(test.title);
+        
+        let status_id;
+        switch(result.status) {
+          case 'passed':
+            status_id = this.qaTouch.statusConfig('Passed');
+            break;
+          case 'failed':
+          case 'timedOut':
+          case 'interrupted':
+            status_id = this.qaTouch.statusConfig('Failed');
+            break;
+          case 'skipped':
+          default:
+            status_id = this.qaTouch.statusConfig('Untested');
+            break;
+        }
 
-            if (caseIds.length > 0) {
-                const results = caseIds.map(caseId => ({
-                    case_id: caseId,
-                    status_id: status_id,
-                }));
-                this.results.push(...results);
-            }
+        if (caseIds.length > 0) {
+            const results = caseIds.map(caseId => ({
+                case_id: caseId,
+                status_id: status_id,
+            }));
+            this.results.push(...results);
         }
        console.log(`Finished test ${test.title}: ${result.status}`);
     }


### PR DESCRIPTION
Without the PR : 
Only playwright status that is handled by this reporter is 'Passed', So when tests are failed, status is not updated on Qa touch

With The PR : 
Test Cases status are updated no matter is Playwright status.

List of Playwright test status https://playwright.dev/docs/api/class-testresult#test-result-status
